### PR TITLE
Add simple Streamlit map app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # ys_map_price
+
+This repository contains a simple Streamlit example that displays a map using PyDeck.
+
+## Running the app
+
+Install the required dependencies and start the app with Streamlit:
+
+```
+streamlit run app.py
+```
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,32 @@
+import streamlit as st
+import pydeck as pdk
+import pandas as pd
+
+st.title("Sample Map")
+
+# Example data for a single point (San Francisco)
+data = pd.DataFrame(
+    {
+        "lat": [37.7749],
+        "lon": [-122.4194],
+    }
+)
+
+layer = pdk.Layer(
+    "ScatterplotLayer",
+    data=data,
+    get_position="[lon, lat]",
+    get_color="[200, 30, 0, 160]",
+    get_radius=200,
+)
+
+view_state = pdk.ViewState(
+    latitude=data.loc[0, "lat"],
+    longitude=data.loc[0, "lon"],
+    zoom=10,
+)
+
+r = pdk.Deck(layers=[layer], initial_view_state=view_state)
+
+st.pydeck_chart(r)
+


### PR DESCRIPTION
## Summary
- create `app.py` with a PyDeck map example
- update README with instructions on running the Streamlit app

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6865eb1170a08332a5e7d16bca727f39